### PR TITLE
Bugfix for non int Shotgun framerange data

### DIFF
--- a/app.py
+++ b/app.py
@@ -192,6 +192,10 @@ class SetFrameRange(Application):
             Application.SetValue("PlayControl.In", in_frame)
             Application.SetValue("PlayControl.Out", out_frame)
 
+            # set frame ranges for rendering
+            Application.SetValue("Passes.RenderOptions.FrameStart", in_frame, "")
+            Application.SetValue("Passes.RenderOptions.FrameEnd", out_frame, "")
+
         elif engine == "tk-houdini":
             import hou
             hou.playbar.setPlaybackRange(in_frame, out_frame)


### PR DESCRIPTION
Hi guys,

The Shotgun field we are using here for frameIn/frameOut is of type 'text' and was  causing the setFrameRange call to fail with the following error:

> Traceback (most recent call last):
>    File "/rdo/rodeo/repositories/tank/studio/install/apps/app_store/tk-multi-setframerange/v0.1.7/app.py", line 57, in run_app
>      message += "New start frame: %d\n\n" % new_in
>  TypeError: int argument required

I added a cast for the new_in/new_out in the message to get rid of it.

I also added 2 lines to set the framerange in the Softimage render options.

Cheers
Julien
