### PR TITLE
#23021: 3DS Max Engine w/MaxPlus

### DIFF
--- a/app.py
+++ b/app.py
@@ -144,7 +144,7 @@ class SetFrameRange(Application):
             from Py3dsMax import mxs
             current_in = mxs.animationRange.start
             current_out = mxs.animationRange.end
-        elif engine == "tk-3dsmax-plus":
+        elif engine == "tk-3dsmaxplus":
             import MaxPlus
             ticks = MaxPlus.Core.EvalMAXScript("ticksperframe").GetInt()
             current_in = MaxPlus.Animation.GetAnimRange().Start() / ticks
@@ -216,7 +216,7 @@ class SetFrameRange(Application):
         elif engine == "tk-3dsmax":
             from Py3dsMax import mxs
             mxs.animationRange = mxs.interval(in_frame, out_frame)
-        elif engine == "tk-3dsmax-plus":
+        elif engine == "tk-3dsmaxplus":
             import MaxPlus 
             ticks = MaxPlus.Core.EvalMAXScript("ticksperframe").GetInt()
             range = MaxPlus.Interval(in_frame * ticks, out_frame * ticks)

--- a/info.yml
+++ b/info.yml
@@ -42,4 +42,4 @@ requires_core_version: "v0.12.5"
 requires_engine_version:
 
 # the engines that this app can operate in:
-supported_engines: [tk-nuke, tk-maya, tk-motionbuilder, tk-softimage, tk-houdini, tk-3dsmax, tk-3dsmax-plus]
+supported_engines: [tk-nuke, tk-maya, tk-motionbuilder, tk-softimage, tk-houdini, tk-3dsmax, tk-3dsmaxplus]


### PR DESCRIPTION
Updated engine to work with MaxPlus instead of Blur's python distribution for 3ds max, thus removing the dependency.
