### PR TITLE
Make current_in/out integers to beautify popup msg

### DIFF
--- a/app.py
+++ b/app.py
@@ -119,8 +119,8 @@ class SetFrameRange(Application):
 
         elif engine == "tk-nuke":
             import nuke
-            current_in = nuke.root()["first_frame"].value()
-            current_out = nuke.root()["last_frame"].value()
+            current_in = int(nuke.root()["first_frame"].value())
+            current_out = int(nuke.root()["last_frame"].value())
 
         elif engine == "tk-motionbuilder":
             from pyfbsdk import FBPlayerControl, FBTime


### PR DESCRIPTION
For nuke, it'd be cool if the frame ranges were tracked as integers...seeing "in frame 1001.0" looks wrong, especially since the output seems to always be an integer.