### PR TITLE
Nuke lock range

### DIFF
--- a/app.py
+++ b/app.py
@@ -182,6 +182,7 @@ class SetFrameRange(Application):
             import nuke
 
             # unlock
+            always_lock = self.get_setting("always_lock_range")
             locked = nuke.root()["lock_range"].value()
             if locked:
                 nuke.root()["lock_range"].setValue(False)
@@ -189,7 +190,8 @@ class SetFrameRange(Application):
             nuke.root()["first_frame"].setValue(in_frame)
             nuke.root()["last_frame"].setValue(out_frame)
             # and lock range
-            nuke.root()["lock_range"].setValue(True)
+            if locked or always_lock:
+                nuke.root()["lock_range"].setValue(True)
 
         elif engine == "tk-motionbuilder":
             from pyfbsdk import FBPlayerControl, FBTime

--- a/app.py
+++ b/app.py
@@ -188,9 +188,8 @@ class SetFrameRange(Application):
             # set values
             nuke.root()["first_frame"].setValue(in_frame)
             nuke.root()["last_frame"].setValue(out_frame)
-            # and lock again
-            if locked:
-                nuke.root()["lock_range"].setValue(True)
+            # and lock range
+            nuke.root()["lock_range"].setValue(True)
 
         elif engine == "tk-motionbuilder":
             from pyfbsdk import FBPlayerControl, FBTime


### PR DESCRIPTION
Added an option to set an "always_lock_range" setting in the tk-nuke.yml settings file. It would be added like this:

`settings.tk-nuke.shot_step:
  apps:
    tk-multi-setframerange:
      location: "@apps.tk-multi-setframerange.location"
      sg_in_frame_field: sg_head_in
      sg_out_frame_field: sg_tail_out
      always_lock_range: true`

This will make it so that it will always lock the range in nuke when the frame range is set by the app.
