### PR TITLE
Moved frame range logic to hook_frame_operation for default supported engines

### DIFF
--- a/hooks/frame_operations_tk-3dsmax.py
+++ b/hooks/frame_operations_tk-3dsmax.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from Py3dsMax import mxs
+
+import sgtk
+from sgtk import TankError
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class FrameOperation(HookBaseClass):
+    """
+    Hook called to perform a frame operation with the 
+    current scene
+    """
+    
+    def execute(self, operation, in_frame=None, out_frame=None, **kwargs):
+        """
+        Main hook entry point
+        
+        :operation: String
+                    Frame operation to perform
+        
+        :in_frame: int
+                    in_frame for the current context (e.g. the current shot, 
+                                                      current asset etc)
+                    
+        :out_frame: int
+                    out_frame for the current context (e.g. the current shot, 
+                                                      current asset etc)
+                    
+        :returns:   Depends on operation:
+                    'set_frame_range' - Returns if the operation was succesfull
+                    'get_frame_range' - Returns the frame range in the form (in_frame, out_frame)
+        """
+
+        if operation == "get_frame_range":
+            current_in = mxs.animationRange.start
+            current_out = mxs.animationRange.end
+            return (current_in, current_out)
+        elif operation == "set_frame_range":
+            mxs.animationRange = mxs.interval(in_frame, out_frame)
+            return True

--- a/hooks/frame_operations_tk-3dsmaxplus.py
+++ b/hooks/frame_operations_tk-3dsmaxplus.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import MaxPlus
+
+import sgtk
+from sgtk import TankError
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class FrameOperation(HookBaseClass):
+    """
+    Hook called to perform a frame operation with the 
+    current scene
+    """
+    
+    def execute(self, operation, in_frame=None, out_frame=None, **kwargs):
+        """
+        Main hook entry point
+        
+        :operation: String
+                    Frame operation to perform
+        
+        :in_frame: int
+                    in_frame for the current context (e.g. the current shot, 
+                                                      current asset etc)
+                    
+        :out_frame: int
+                    out_frame for the current context (e.g. the current shot, 
+                                                      current asset etc)
+                    
+        :returns:   Depends on operation:
+                    'set_frame_range' - Returns if the operation was succesfull
+                    'get_frame_range' - Returns the frame range in the form (in_frame, out_frame)
+        """
+
+        if operation == "get_frame_range":
+            ticks = MaxPlus.Core.EvalMAXScript("ticksperframe").GetInt()
+            current_in = MaxPlus.Animation.GetAnimRange().Start() / ticks
+            current_out = MaxPlus.Animation.GetAnimRange().End() / ticks
+            return (current_in, current_out)
+        elif operation == "set_frame_range":
+            import MaxPlus 
+            ticks = MaxPlus.Core.EvalMAXScript("ticksperframe").GetInt()
+            range = MaxPlus.Interval(in_frame * ticks, out_frame * ticks)
+            MaxPlus.Animation.SetRange(range)
+            return True

--- a/hooks/frame_operations_tk-houdini.py
+++ b/hooks/frame_operations_tk-houdini.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import hou
+
+import sgtk
+from sgtk import TankError
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class FrameOperation(HookBaseClass):
+    """
+    Hook called to perform a frame operation with the 
+    current scene
+    """
+    
+    def execute(self, operation, in_frame=None, out_frame=None, **kwargs):
+        """
+        Main hook entry point
+        
+        :operation: String
+                    Frame operation to perform
+        
+        :in_frame: int
+                    in_frame for the current context (e.g. the current shot, 
+                                                      current asset etc)
+                    
+        :out_frame: int
+                    out_frame for the current context (e.g. the current shot, 
+                                                      current asset etc)
+                    
+        :returns:   Depends on operation:
+                    'set_frame_range' - Returns if the operation was succesfull
+                    'get_frame_range' - Returns the frame range in the form (in_frame, out_frame)
+        """
+
+        if operation == "get_frame_range":
+            current_in, current_out = hou.playbar.playbackRange()
+            return (current_in, current_out)
+        elif operation == "set_frame_range":
+            # We have to use hscript until SideFX gets around to implementing hou.setGlobalFrameRange()
+            hou.hscript("tset `((%s-1)/$FPS)` `(%s/$FPS)`" % (in_frame, out_frame))            
+            hou.playbar.setPlaybackRange(in_frame, out_frame)
+            return True

--- a/hooks/frame_operations_tk-maya.py
+++ b/hooks/frame_operations_tk-maya.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import pymel.core as pm
+import maya.cmds as cmds
+
+import sgtk
+from sgtk import TankError
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class FrameOperation(HookBaseClass):
+    """
+    Hook called to perform a frame operation with the 
+    current scene
+    """
+    
+    def execute(self, operation, in_frame=None, out_frame=None, **kwargs):
+        """
+        Main hook entry point
+        
+        :operation: String
+                    Frame operation to perform
+        
+        :in_frame: int
+                    in_frame for the current context (e.g. the current shot, 
+                                                      current asset etc)
+                    
+        :out_frame: int
+                    out_frame for the current context (e.g. the current shot, 
+                                                      current asset etc)
+                    
+        :returns:   Depends on operation:
+                    'set_frame_range' - Returns if the operation was succesfull
+                    'get_frame_range' - Returns the frame range in the form (in_frame, out_frame)
+        """
+
+        if operation == "get_frame_range":
+            current_in = cmds.playbackOptions(query=True, minTime=True)
+            current_out = cmds.playbackOptions(query=True, maxTime=True)
+            return (current_in, current_out)
+        elif operation == "set_frame_range":
+            # set frame ranges for plackback
+            pm.playbackOptions(minTime=in_frame, 
+                               maxTime=out_frame,
+                               animationStartTime=in_frame,
+                               animationEndTime=out_frame)
+            
+            # set frame ranges for rendering
+            defaultRenderGlobals=pm.PyNode('defaultRenderGlobals')
+            defaultRenderGlobals.startFrame.set(in_frame)
+            defaultRenderGlobals.endFrame.set(out_frame)
+            return True

--- a/hooks/frame_operations_tk-motionbuilder.py
+++ b/hooks/frame_operations_tk-motionbuilder.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from pyfbsdk import FBPlayerControl, FBTime
+
+import sgtk
+from sgtk import TankError
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class FrameOperation(HookBaseClass):
+    """
+    Hook called to perform a frame operation with the 
+    current scene
+    """
+    
+    def execute(self, operation, in_frame=None, out_frame=None, **kwargs):
+        """
+        Main hook entry point
+        
+        :operation: String
+                    Frame operation to perform
+        
+        :in_frame: int
+                    in_frame for the current context (e.g. the current shot, 
+                                                      current asset etc)
+                    
+        :out_frame: int
+                    out_frame for the current context (e.g. the current shot, 
+                                                      current asset etc)
+                    
+        :returns:   Depends on operation:
+                    'set_frame_range' - Returns if the operation was succesfull
+                    'get_frame_range' - Returns the frame range in the form (in_frame, out_frame)
+        """
+
+        if operation == "get_frame_range":
+            lPlayer = FBPlayerControl()
+            current_in = lPlayer.LoopStart.GetFrame()
+            current_out = lPlayer.LoopStop.GetFrame()
+            return (current_in, current_out)
+        elif operation == "set_frame_range":
+            lPlayer = FBPlayerControl()
+            lPlayer.LoopStart = FBTime(0, 0, 0, in_frame)
+            lPlayer.LoopStop = FBTime(0, 0, 0, out_frame)
+            return True

--- a/hooks/frame_operations_tk-nuke.py
+++ b/hooks/frame_operations_tk-nuke.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import nuke
+
+import sgtk
+from sgtk import TankError
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class FrameOperation(HookBaseClass):
+    """
+    Hook called to perform a frame operation with the 
+    current scene
+    """
+    
+    def execute(self, operation, in_frame=None, out_frame=None, **kwargs):
+        """
+        Main hook entry point
+        
+        :operation: String
+                    Frame operation to perform
+        
+        :in_frame: int
+                    in_frame for the current context (e.g. the current shot, 
+                                                      current asset etc)
+                    
+        :out_frame: int
+                    out_frame for the current context (e.g. the current shot, 
+                                                      current asset etc)
+                    
+        :returns:   Depends on operation:
+                    'set_frame_range' - Returns if the operation was succesfull
+                    'get_frame_range' - Returns the frame range in the form (in_frame, out_frame)
+        """
+
+        engine = tank.platform.current_engine()
+        if engine.hiero_enabled:
+            raise TankError("Not supported frame operation for hiero")
+
+        if operation == "get_frame_range":
+            current_in = int(nuke.root()["first_frame"].value())
+            current_out = int(nuke.root()["last_frame"].value())
+            return (current_in, current_out)
+        elif operation == "set_frame_range":
+            # unlock
+            locked = nuke.root()["lock_range"].value()
+            if locked:
+                nuke.root()["lock_range"].setValue(False)
+            # set values
+            nuke.root()["first_frame"].setValue(in_frame)
+            nuke.root()["last_frame"].setValue(out_frame)
+            # and lock again
+            if locked:
+                nuke.root()["lock_range"].setValue(True)
+            return True

--- a/hooks/frame_operations_tk-softimage.py
+++ b/hooks/frame_operations_tk-softimage.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import win32com
+
+import sgtk
+from sgtk import TankError
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class FrameOperation(HookBaseClass):
+    """
+    Hook called to perform a frame operation with the 
+    current scene
+    """
+    
+    def execute(self, operation, in_frame=None, out_frame=None, **kwargs):
+        """
+        Main hook entry point
+        
+        :operation: String
+                    Frame operation to perform
+        
+        :in_frame: int
+                    in_frame for the current context (e.g. the current shot, 
+                                                      current asset etc)
+                    
+        :out_frame: int
+                    out_frame for the current context (e.g. the current shot, 
+                                                      current asset etc)
+                    
+        :returns:   Depends on operation:
+                    'set_frame_range' - Returns if the operation was succesfull
+                    'get_frame_range' - Returns the frame range in the form (in_frame, out_frame)
+        """
+
+        if operation == "get_frame_range":
+            xsi = win32com.client.Dispatch('XSI.Application')
+            
+            current_in = xsi.GetValue("PlayControl.In")
+            current_out = xsi.GetValue("PlayControl.Out")
+            return (current_in, current_out)
+        elif operation == "set_frame_range":
+            Application = win32com.client.Dispatch('XSI.Application')
+
+            # set playback control
+            Application.SetValue("PlayControl.In", in_frame)
+            Application.SetValue("PlayControl.Out", out_frame)
+            Application.SetValue("PlayControl.GlobalIn", in_frame)
+            Application.SetValue("PlayControl.GlobalOut", out_frame)       
+
+            # set frame ranges for rendering
+            Application.SetValue("Passes.RenderOptions.FrameStart", in_frame)
+            Application.SetValue("Passes.RenderOptions.FrameEnd", out_frame)
+
+            return True

--- a/info.yml
+++ b/info.yml
@@ -28,6 +28,11 @@ configuration:
                      for this field on the entity associated with the current context (e.g.
                      the current shot, current asset etc).
         
+    # hooks
+    hook_frame_operation:
+        type: hook
+        default_value: "{self}/frame_operations_{engine_name}.py"
+        description: Hook which contains all methods for setting/getting frame ranges.
 
 # the Shotgun fields that this app needs in order to operate correctly
 requires_shotgun_fields:

--- a/info.yml
+++ b/info.yml
@@ -47,4 +47,4 @@ requires_core_version: "v0.12.5"
 requires_engine_version:
 
 # the engines that this app can operate in:
-supported_engines: [tk-nuke, tk-maya, tk-motionbuilder, tk-softimage, tk-houdini, tk-3dsmax, tk-3dsmaxplus]
+supported_engines:


### PR DESCRIPTION
Moving all the frame range logic to an actual hook allows engines to customize the set/get frame range logic independently. 
I have also removed the list of default supported engines from info.yml so other engines can be supported by implementing this hook.