### PR TITLE
SG-14278 Add the ability to register a different menu name

### DIFF
--- a/app.py
+++ b/app.py
@@ -34,7 +34,9 @@ class SetFrameRange(Application):
                                  "a current Shot, current Asset etc). This app requires "
                                  "an entity as part of the context in order to work.")
 
-        self.engine.register_command("Sync Frame Range with Shotgun", self.run_app)
+        # We grab the menu name from the settings so that the user is able to register multiple instances
+        # of this app with different frame range fields configured.
+        self.engine.register_command(self.get_setting("menu_name"), self.run_app)
 
     @property
     def context_change_allowed(self):

--- a/info.yml
+++ b/info.yml
@@ -13,6 +13,11 @@
 
 # expected fields in the configuration file for this app
 configuration:
+
+    menu_name:
+        type: str
+        default_value: "Sync Frame Range with Shotgun"
+        description: The name that will be shown in the Shotgun menu.
     
     sg_in_frame_field:
         type: str


### PR DESCRIPTION
The pull request allows for registering the app with different menu names. This allows you to configure multiple instances of the app on an engine so that you can have different options for syncing with different fields in Shotgun.
<img width="265" alt="Sync_frame_range_with_Shotgun_and_Shotgun_and_Autodesk_Maya_2019__untitled" src="https://user-images.githubusercontent.com/3777228/66561146-d120a780-eb50-11e9-921b-590c254f95b0.png">
