### PR TITLE
SG-33493 Fixes an issue when the hook_frame_operation does not return the right data type

### DIFF
--- a/app.py
+++ b/app.py
@@ -177,8 +177,7 @@ class SetFrameRange(Application):
             raise tank.TankError(
                 "Unexpected type returned from 'hook_frame_operation' for operation get_"
                 "frame_range - expected a 'tuple' with (in_frame, out_frame) values but "
-                "returned '%s' : %s" % (type(result).__name__),
-                result,
+                "returned '%s' : %s" % (type(result).__name__, result)
             )
         return result
 


### PR DESCRIPTION
Just a little typo, the `result` variable should be part of the tuple to be able to avoid a typerror:
TypeError: not enough arguments for format string