### PR TITLE
SG-36404 - Accurately get the frame range from Houdini

### DIFF
--- a/hooks/frame_operations_tk-houdini.py
+++ b/hooks/frame_operations_tk-houdini.py
@@ -26,9 +26,12 @@ class FrameOperation(HookBaseClass):
         get_frame_range will return a tuple of (in_frame, out_frame)
 
         :returns: Returns the frame range in the form (in_frame, out_frame)
-        :rtype: tuple[int, int]
+        :rtype: tuple[float, float]
         """
-        current_in, current_out = hou.playbar.playbackRange()
+        # Get the global start and end frame
+        # Note, when using hou.playbar.playbackRange(), unpacking the start frame returns `1001.0000000000001`,
+        # thus will incorrectly flag the scene sync summary pop up to show, if the PTR start frame is 1001.0
+        current_in, current_out = hou.playbar.frameRange()
         return (current_in, current_out)
 
     def set_frame_range(self, in_frame=None, out_frame=None, **kwargs):


### PR DESCRIPTION
This is a more precise way of retrieving the frame range from Houdini and ensures it's the correct value to compare against